### PR TITLE
Format currencies with maximum fraction digits of 2

### DIFF
--- a/src/components/AreaChart.js
+++ b/src/components/AreaChart.js
@@ -7,7 +7,7 @@ import {
   defaultStyles,
   withTooltip,
 } from "@visx/tooltip";
-import { formatCurrency, oneMonth, oneWeek } from "app/core";
+import { formatCurrency, formatPrice, oneMonth, oneWeek } from "app/core";
 import { scaleLinear, scaleTime } from "@visx/scale";
 import { useCallback, useMemo, useState } from "react";
 
@@ -38,6 +38,7 @@ function AreaChart({
   data,
   tooltipDisabled = false,
   overlayEnabled = false,
+  priceFormat = false,
   title = "",
   width,
   height,
@@ -74,7 +75,7 @@ function AreaChart({
 
   const [overlay, setOverlay] = useState({
     title,
-    value: formatCurrency(data[data.length - 1]?.value),
+    value: (priceFormat ? formatPrice : formatCurrency)(data[data.length - 1]?.value),
     date: data[data.length - 1]?.date,
   });
 
@@ -129,7 +130,7 @@ function AreaChart({
       // console.log("show ", d);
       setOverlay({
         ...overlay,
-        value: formatCurrency(d?.value),
+        value: (priceFormat ? formatPrice : formatCurrency)(d?.value),
         date: d?.date,
       });
       showTooltip({
@@ -175,7 +176,7 @@ function AreaChart({
             hideTooltip();
             setOverlay({
               ...overlay,
-              value: formatCurrency(data[data.length - 1]?.value),
+              value: (priceFormat ? formatPrice : formatCurrency)(data[data.length - 1]?.value),
               date: data[data.length - 1]?.date,
             });
           }}

--- a/src/components/TokenTable.js
+++ b/src/components/TokenTable.js
@@ -13,7 +13,7 @@ import React from "react";
 import SortableTable from "./SortableTable";
 import { TOKEN_DENY } from "app/core/constants";
 import TokenIcon from "./TokenIcon";
-import { formatCurrency } from "app/core";
+import { formatCurrency, formatPrice } from "app/core";
 import { useQuery } from "@apollo/client";
 
 const useStyles = makeStyles((theme) => ({
@@ -108,7 +108,7 @@ export default function TokenTable({ tokens, title }) {
             key: "price",
             align: "right",
             label: "Price",
-            render: (row) => formatCurrency(row.price),
+            render: (row) => formatPrice(row.price),
           },
           {
             key: "priceChange",

--- a/src/core/format.js
+++ b/src/core/format.js
@@ -24,6 +24,10 @@ export const decimalFormatter = new Intl.NumberFormat(locales, {
 export const formatDate = timeFormat("%b %d, '%y");
 
 export function formatCurrency(value) {
+  return currencyFormatter.format(value);
+}
+
+export function formatPrice(value) {
   if (value < 10) {
     return tinyCurrencyFormatter.format(value);
   }

--- a/src/pages/tokens/[id].js
+++ b/src/pages/tokens/[id].js
@@ -32,6 +32,7 @@ import {
   transactionsQuery,
   useInterval,
   TokenInfo,
+  formatPrice,
 } from "app/core";
 
 import Head from "next/head";
@@ -287,7 +288,7 @@ function TokenPage() {
           <Grid item xs={12} md={12}>
             <KPI
               title="Price (24h)"
-              value={formatCurrency(price || 0)}
+              value={formatPrice(price || 0)}
               difference={priceChange}
             />
           </Grid>

--- a/src/pages/tokens/[id].js
+++ b/src/pages/tokens/[id].js
@@ -178,7 +178,7 @@ function TokenPage() {
     <AppShell>
       <Head>
         <title>
-          {formatCurrency(price || 0)} | {token.symbol} | MistSwap
+          {formatPrice(price || 0)} | {token.symbol} | MistSwap
           Analytics
         </title>
       </Head>
@@ -198,7 +198,7 @@ function TokenPage() {
             </Box>
             <Box display="flex" alignItems="center" className={classes.price}>
               <Typography variant="h6" component="div">
-                {formatCurrency(price || 0)}
+                {formatPrice(price || 0)}
               </Typography>
               <Percent percent={priceChange} ml={1} />
             </Box>
@@ -238,6 +238,7 @@ function TokenPage() {
                   margin={{ top: 125, right: 0, bottom: 0, left: 0 }}
                   tooltipDisabled
                   overlayEnabled
+                  priceFormat
                 />
               )}
             </ParentSize>


### PR DESCRIPTION
Assess #23
Tiny currency formatter uses 2 fraction digits instead of 6.